### PR TITLE
Feat(interceptors): Added interceptors

### DIFF
--- a/src/service/angular-sails.js
+++ b/src/service/angular-sails.js
@@ -1,37 +1,39 @@
 /*jslint sloppy:true*/
 /*global angular, io */
-angular.module('ngSails').provider('$sails', function () {
+angular.module('ngSails', []).provider('$sails', function () {
     var provider = this,
         httpVerbs = ['get', 'post', 'put', 'delete'],
         eventNames = ['on', 'once'];
 
     this.url = undefined;
-    this.interceptors = [];
+    var interceptorFactories = this.interceptors = [];
+    var responseInterceptorFactories = this.responseInterceptors = [];
 
-    this.$get = ['$q', '$timeout', function ($q, $timeout) {
-        var socket = io.connect(provider.url),
-            defer = function () {
-                var deferred = $q.defer(),
-                    promise = deferred.promise;
+    this.$get = ['$q', '$timeout', '$injector', function ($q, $timeout, $injector) {
 
-                promise.success = function (fn) {
-                    return promise.then(fn);
-                };
+        var reversedInterceptors = [];
 
-                promise.error = function (fn) {
-                    return promise.then(null, fn);
-                };
+        angular.forEach(interceptorFactories, function (interceptorFactory) {
+            reversedInterceptors.unshift(angular.isString(interceptorFactory)
+                ? $injector.get(interceptorFactory) : $injector.invoke(interceptorFactory));
+        });
 
-                return deferred;
-            },
-            resolveOrReject = function (deferred, data) {
-                // Make sure what is passed is an object that has a status and if that status is no 2xx, reject.
-                if (data && angular.isObject(data) && data.status && Math.floor(data.status / 100) !== 2) {
-                    deferred.reject(data);
-                } else {
-                    deferred.resolve(data);
+        angular.forEach(responseInterceptorFactories, function (interceptorFactory, index) {
+            var responseFn = angular.isString(interceptorFactory)
+                ? $injector.get(interceptorFactory)
+                : $injector.invoke(interceptorFactory);
+
+            reversedInterceptors.splice(index, 0, {
+                response: function (response) {
+                    return responseFn($q.when(response));
+                },
+                responseError: function (response) {
+                    return responseFn($q.reject(response));
                 }
-            },
+            });
+        });
+
+        var socket = io.connect(provider.url),
             angularify = function (cb, data) {
                 $timeout(function () {
                     cb(data);
@@ -40,16 +42,58 @@ angular.module('ngSails').provider('$sails', function () {
             promisify = function (methodName) {
                 socket['legacy_' + methodName] = socket[methodName];
                 socket[methodName] = function (url, data, cb) {
-                    var deferred = defer();
                     if (cb === undefined && angular.isFunction(data)) {
                         cb = data;
                         data = null;
                     }
-                    deferred.promise.then(cb);
-                    socket['legacy_' + methodName](url, data, function (result) {
-                        resolveOrReject(deferred, result);
+
+                    function sendRequest(config) {
+                        var deferred = $q.defer();
+
+                        socket['legacy_' + methodName](config.url, config.data, function (data) {
+                            if (data && angular.isObject(data) && data.status && Math.floor(data.status / 100) !== 2) {
+                                deferred.reject(data);
+                            } else {
+                                deferred.resolve(data);
+                            }
+                        });
+
+                        return deferred.promise;
+                    }
+
+                    var chain = [sendRequest, undefined];
+                    var promise = $q.when({url: url, data: data, cb: cb});
+
+
+                    angular.forEach(reversedInterceptors, function (interceptor) {
+                        if (interceptor.request || interceptor.requestError) {
+                            chain.unshift(interceptor.request, interceptor.requestError);
+                        }
+                        if (interceptor.response || interceptor.responseError) {
+                            chain.push(interceptor.response, interceptor.responseError);
+                        }
                     });
-                    return deferred.promise;
+
+                    while (chain.length) {
+                        var thenFn = chain.shift();
+                        var rejectFn = chain.shift();
+
+                        promise = promise.then(thenFn, rejectFn);
+                    }
+
+                    promise.then(cb, null);
+
+                    promise.success = function (fn) {
+                        promise.then(fn);
+                        return promise;
+                    };
+
+                    promise.error = function (fn) {
+                        promise.then(null, fn);
+                        return promise;
+                    };
+
+                    return promise;
                 };
             },
             wrapEvent = function (eventName) {


### PR DESCRIPTION
Added interceptors because I like this project.
Completes #5 

Simple Usage (in `config`):

``` javascript
$sailsProvider.interceptors.push(['$q', function ($q) {
    return{
        request: function (config) {
            // ... stuff
            return config || $q.when(config);
        },
        response: function (response) {
            // ... stuff
            return response || $q.when(response);
        },
        requestError: function (config) {
            // ... stuff
            return $q.reject(reason);
        },
        responseError: function (response) {
            // ... stuff
            return $q.reject(reason);
        }
    }
}]);
```

Have as many as you want, push more to the `$sailsProvider.interceptors` array.
Should support the same things as [$http interceptors](http://code.angularjs.org/1.2.15/docs/api/ng/service/$http#interceptors).

I only tested it for my use case :(  Sorry no actual test scripts.
