### PR TITLE
Fix(Promise): now you can .error your .success

### DIFF
--- a/src/service/angular-sails.js
+++ b/src/service/angular-sails.js
@@ -15,11 +15,13 @@ angular.module('ngSails').provider('$sails', function () {
                     promise = deferred.promise;
 
                 promise.success = function (fn) {
-                    return promise.then(fn);
+                    promise.then(fn);
+                    return promise;
                 };
 
                 promise.error = function (fn) {
-                    return promise.then(null, fn);
+                    promise.then(null, fn);
+                    return promise;
                 };
 
                 return deferred;


### PR DESCRIPTION
Fixes #12 by returning the original promise which has the `.error` and `.success` and not the new promise which is returned by `.then`
