### PR TITLE
prevent string status

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,27 @@ app.controller("FooController", function ($scope, $sails) {
 });
 ```
 
+defined status rule: return value if it is `true`, will trigger success event, otherwise `false`, trigger error event. 
+
+```javascript
+var app = angular.module("MyApp", ['ngSails']);
+
+//OPTIONAL! Set socket URL!
+app.config(['$sailsProvider', function ($sailsProvider) {
+    $sailsProvider.statusRule = function (data) {
+        if (data.status == "ok") {
+            return true;
+        }
+
+        if (data.status == "fails") {
+            return false;
+        }
+
+        return true;
+    };
+}]);
+```
+
 API Refenrence
 --------------
 

--- a/src/service/angular-sails.js
+++ b/src/service/angular-sails.js
@@ -35,7 +35,14 @@ angular.module('ngSails').provider('$sails', function () {
                 
                 // means status is a status Number
                 var status = data.status;
-                if (status.match(/\d+/)[0].length === status.length && Math.floor(status / 100) !== 2) {
+                var isNumber = status.match(/\d+/);
+                
+                // status is not Number
+                if ( ! isNumber) {
+                    return deferred.resolve(data);
+                }
+                
+                if (isNumber[0].length === status.length && Math.floor(status / 100) !== 2) {
                     return deferred.reject(data);
                 }
                 

--- a/src/service/angular-sails.js
+++ b/src/service/angular-sails.js
@@ -10,7 +10,7 @@ angular.module('ngSails').provider('$sails', function () {
 
     this.statusRule = function (data) {
         data = data || { status: 400 };
-        if (angular.isObject(data) && data.status) {
+        if ( ! angular.isObject(data)) {
             return false;
         }
 

--- a/src/service/angular-sails.js
+++ b/src/service/angular-sails.js
@@ -28,11 +28,19 @@ angular.module('ngSails').provider('$sails', function () {
             },
             resolveOrReject = function (deferred, data) {
                 // Make sure what is passed is an object that has a status and if that status is no 2xx, reject.
-                if (data && angular.isObject(data) && data.status && Math.floor(data.status / 100) !== 2) {
-                    deferred.reject(data);
-                } else {
-                    deferred.resolve(data);
+                data = data || { status: 400 };
+                if (angular.isObject(data) && data.status) {
+                    return deferred.reject(data);
                 }
+                
+                // means status is a status Number
+                var status = data.status;
+                if (status.match(/\d+/)[0].length === status.length && Math.floor(status / 100) !== 2) {
+                    return deferred.reject(data);
+                }
+                
+                // Otherwise, the respose will be a String.
+                return deferred.resolve(data);
             },
             angularify = function (cb, data) {
                 $timeout(function () {

--- a/src/service/angular-sails.js
+++ b/src/service/angular-sails.js
@@ -35,14 +35,15 @@ angular.module('ngSails').provider('$sails', function () {
                 
                 // means status is a status Number
                 var status = data.status;
-                var isNumber = status.match(/\d+/);
+                var isNotaNumber = isNaN(status);
                 
                 // status is not Number
-                if ( ! isNumber) {
+                if (isNotaNumber) {
                     return deferred.resolve(data);
                 }
                 
-                if (isNumber[0].length === status.length && Math.floor(status / 100) !== 2) {
+                // After condition status should be a number, then process status
+                if (Math.floor(status / 100) !== 2) {
                     return deferred.reject(data);
                 }
                 


### PR DESCRIPTION
if result status is a string, ex, "ok", "success". 

Origin it will trigger Error event.
Maybe we can default set if status type is String then response success event.
Otherwise, check status is an number, then enter to condition.