### PR TITLE
feat(responseHandler): init

### DIFF
--- a/src/service/angular-sails.js
+++ b/src/service/angular-sails.js
@@ -7,6 +7,7 @@ angular.module('ngSails').provider('$sails', function () {
 
     this.url = undefined;
     this.interceptors = [];
+    this.responseHandler = undefined;
 
     this.$get = ['$q', '$timeout', function ($q, $timeout) {
         var socket = io.connect(provider.url),
@@ -15,18 +16,20 @@ angular.module('ngSails').provider('$sails', function () {
                     promise = deferred.promise;
 
                 promise.success = function (fn) {
-                    return promise.then(fn);
+                    promise.then(fn);
+                    return promise;
                 };
 
                 promise.error = function (fn) {
-                    return promise.then(null, fn);
+                    promise.then(null, fn);
+                    return promise;
                 };
 
                 return deferred;
             },
-            resolveOrReject = function (deferred, data) {
-                // Make sure what is passed is an object that has a status and if that status is no 2xx, reject.
-                if (data && angular.isObject(data) && data.status && Math.floor(data.status / 100) !== 2) {
+            resolveOrReject = this.responseHandler || function (deferred, data) {
+                // Make sure what is passed is an object that has a status that is a number and if that status is no 2xx, reject.
+                if (data && angular.isObject(data) && data.status && !isNaN(data.status) && Math.floor(data.status / 100) !== 2) {
                     deferred.reject(data);
                 } else {
                     deferred.resolve(data);


### PR DESCRIPTION
Added ability for a custom response handler to be set in the provider during config.  This handler will accept a deferred object (to reject or resolve) and the data returned by the socket call.
Also modified the default handler to resolve if the data.status is `NaN`.

This is a less opinionated approach and allows the end user to do more by specifying custom logic for determining if a socket call returned success or failure.
