### PR TITLE
Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ npm-debug.log
 node_modules
 
 .tern-project
+/.idea/


### PR DESCRIPTION
Hi came up with a refactored version of angular-sails and set it open for discussion:

* Set `io.sails.autoConnect = false;` to false to be able to use angular.config
* Full request and response interceptor support
* configureable `base` url as counterpart of `sails.config.blueprint.prefix`
* breaking change! Killed the `cb` param and added a config/meta obj which gets attached to the `req` and `res`. Using a promise here is the angular-way
* helper method to listen/react on/for model-updates (currently depends  on lodash)