### PR TITLE
Added callback to modelUpdater

### DIFF
--- a/src/service/angular-sails.js
+++ b/src/service/angular-sails.js
@@ -252,7 +252,10 @@
 
                             case "created":
                                 // create new model item
-                                models.push(message.data);
+                                var len = models.push(message.data);
+                                if (callback) {
+                                    callback(models[len-1], message.verb);
+                                }
                                 break;
 
                             case "updated":
@@ -276,14 +279,22 @@
 
                                 // update the model item
                                 angular.extend(obj, message.data);
+                                if (callback) {
+                                    callback(obj, message.verb);
+                                }
                                 break;
 
                             case "destroyed":
+                            	var destroyedObj;
                                 for (i = 0; i < models.length; i++) {
                                     if (models[i].id === message.id) {
+                                        destroyedObj = models[i];
                                         models.splice(i, 1);
                                         break;
                                     }
+                                }
+                                if (callback && destroyedObj) {
+                                    callback(destroyedObj, message.verb);
                                 }
                                 break;
                         }

--- a/src/service/angular-sails.js
+++ b/src/service/angular-sails.js
@@ -241,7 +241,7 @@
              * @param {String} name       Sails model name
              * @param {Array} models      Array with model objects
              */
-            socket.$modelUpdater = function(name, models) {
+            socket.$modelUpdater = function(name, models, callback) {
 
                 var update = function(message) {
 


### PR DESCRIPTION


This is my first ever pull request so apologies in advance for all that might entail.

It would be really nice to be able to have a callback option for the modelUpdater so that if something changes in the model that callback can be fired. While most applications can probably get away without such and just relying on data binding changes, sometimes you want some logic to occur outside that scope. In my particular case, in using UI-Grid, modelUpdater was updating a field in the model which wasn't being tracked by UI-Grid but which was being relied upon to effect a change in CSS class for a cell in the UI-Grid, so when a change occurred, I needed to call a method to force an update to the UI-Grid to account for possible changes in the cell's CSS class. While I didn't actually personally need to know the object itself or the type of change that occurred, I thought those would be good to have for other use cases.
