### PR TITLE
Allow setting and injection of CSRF tokens

### DIFF
--- a/dist/angular-sails.js
+++ b/dist/angular-sails.js
@@ -71,14 +71,28 @@ angular.module('ngSails', ['ng']);
         // like https://docs.angularjs.org/api/ng/service/$http#interceptors
         // but with sails.io arguments
         var interceptorFactories = this.interceptors = [
-            /*function($injectables) {
+            function($injector) {
                 return {
-                    request: function(config) {},
-                    response: function(response) {},
-                    requestError: function(rejection) {},
-                    responseError: function(rejection) {}
+                    request: function (config) {
+                        var socket = $injector.get('$sails');
+                        if (socket.csrfToken && config.method !== "GET") {
+                            if (config.data == undefined) {
+                                config.data = {
+                                    _csrf: socket.csrfToken
+                                };
+                            }
+                            else if (!config.data._csrf) {
+                                config.data._csrf = socket.csrfToken;
+                            }
+                        }
+                        return config;
+                    }/*,
+                     response: function(response) {},
+                     requestError: function(rejection) {},
+                     responseError: function(rejection) {}
+                     }*/
                 };
-            }*/
+            }
         ];
 
         /*@ngInject*/
@@ -98,6 +112,10 @@ angular.module('ngSails', ['ng']);
                     socket._connect();
                 }
                 return socket;
+            };
+            socket.csrfToken = undefined;
+            socket.setCSRFToken = function(csrfToken){
+                socket.csrfToken = csrfToken;
             };
 
             // TODO: separate out interceptors into its own file (and provider?).

--- a/dist/angular-sails.js
+++ b/dist/angular-sails.js
@@ -74,14 +74,18 @@ angular.module('ngSails', ['ng']);
             function($injector) {
                 return {
                     request: function (config) {
+                        //Get socket from service
                         var socket = $injector.get('$sails');
+                        //If we've got a CSRF token set and it's not a GET request then inject it
                         if (socket.csrfToken && config.method !== "GET") {
+                            //If data is empty then set the data object to just be CSRF token
                             if (config.data == undefined) {
                                 config.data = {
                                     _csrf: socket.csrfToken
                                 };
                             }
                             else if (!config.data._csrf) {
+                                //If data's set and CSRF isn't then inject it
                                 config.data._csrf = socket.csrfToken;
                             }
                         }
@@ -113,7 +117,9 @@ angular.module('ngSails', ['ng']);
                 }
                 return socket;
             };
+            //CSRF token set against socket
             socket.csrfToken = undefined;
+            //Function to allow the call of $sails.setCSRFToken("yourTokenFromServer");
             socket.setCSRFToken = function(csrfToken){
                 socket.csrfToken = csrfToken;
             };


### PR DESCRIPTION
Allows the setting of a CSRF token by calling 
$sails.setCSRFToken("yourTokenFromServer");

Ensures injection without overwriting on all PUT, DELETE and POST requests