### PR TITLE
Issue #60 - `off` with function doesn't work

### DIFF
--- a/src/service/angular-sails.js
+++ b/src/service/angular-sails.js
@@ -209,19 +209,22 @@
             }
 
             function wrapEvent(eventName) {
-            	var wrapEventFn = null;
-                if(socket[eventName] || socket._raw && socket._raw[eventName]){
+                if(socket[eventName] || socket._raw && socket._raw[eventName]) {
                     socket['legacy_' + eventName] = socket[eventName] || socket._raw[eventName];
                     socket[eventName] = function(event, cb) {
+                    	var wrapEventFn = null;
                         if (cb !== null && angular.isFunction(cb)) {
-                          wrapEventFn = function(result) {
-                            $rootScope.$evalAsync(cb.bind(socket, result));
-                          };
-                          socket['legacy_' + eventName](event, wrapEventFn);
+                          if (eventName == 'off') {
+                        	  socket['legacy_' + eventName](event, cb);
+                          } else {
+	                          socket['legacy_' + eventName](event, wrapEventFn = function(result) {
+	                            $rootScope.$evalAsync(cb.bind(socket, result));
+	                          });
+                          }
                         }
+                        return wrapEventFn;
                     };
                 }
-                return wrapEventFn;
             }
 
             // sails.io.js doesn't have `once`, need to access it through `._raw`

--- a/src/service/angular-sails.js
+++ b/src/service/angular-sails.js
@@ -209,16 +209,19 @@
             }
 
             function wrapEvent(eventName) {
+            	var wrapEventFn = null;
                 if(socket[eventName] || socket._raw && socket._raw[eventName]){
                     socket['legacy_' + eventName] = socket[eventName] || socket._raw[eventName];
                     socket[eventName] = function(event, cb) {
                         if (cb !== null && angular.isFunction(cb)) {
-                            socket['legacy_' + eventName](event, function(result) {
-                                $rootScope.$evalAsync(cb.bind(socket, result));
-                            });
+                          wrapEventFn = function(result) {
+                            $rootScope.$evalAsync(cb.bind(socket, result));
+                          };
+                          socket['legacy_' + eventName](event, wrapEventFn);
                         }
                     };
                 }
+                return wrapEventFn;
             }
 
             // sails.io.js doesn't have `once`, need to access it through `._raw`

--- a/test/angular-sails-service.spec.js
+++ b/test/angular-sails-service.spec.js
@@ -109,12 +109,18 @@ describe('Agnular Sails service', function() {
     describe('on', function() {
 
         it('should apply asynchronously', function () {
-            $sails.on('event', spy);
+            var eventHandler = $sails.on('event', spy);
             mockIoSocket.emit('event');
 
             expect(spy).to.have.been.not.called;
             $scope.$digest();
 
+            expect(spy).to.have.been.calledOnce;
+            
+            $sails.off('event', eventHandler);
+            mockIoSocket.emit('event');
+            $scope.$digest();
+            
             expect(spy).to.have.been.calledOnce;
         });
 


### PR DESCRIPTION
Usage:
var eventType = "message";
var eventTypeFn = $sails.on(eventType);
$scope.$on('$destroy', function() {
......
$sails.off(eventType, eventTypeFn);
.....
});